### PR TITLE
Remove nodeSelector configuration from front-deployment

### DIFF
--- a/maskshop-chart/templates/front-deployment.yaml
+++ b/maskshop-chart/templates/front-deployment.yaml
@@ -20,5 +20,3 @@ spec:
         env:
         - name: INITDB
           value: "true"
-      nodeSelector:
-        type: web


### PR DESCRIPTION
It is not a true bug, but it does not allow deploying the chart from the box